### PR TITLE
⬆️  Upgrade to latest version of hmpps plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.1.2"
+    id("uk.gov.justice.hmpps.gradle-spring-boot") version "2.0.0"
     kotlin("plugin.spring") version "1.4.10"
     id("org.unbroken-dome.xjc") version "2.0.0"
     id("org.owasp.dependencycheck") version "6.0.3"


### PR DESCRIPTION
Not strictly necessary as I hadn't twigged that CPG already has the agent set up but this will add version 3 of the agent plus whatever other updates which is no bad thing.