### PR TITLE
Pic 901 revert agent update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY --from=builder --chown=appuser:appgroup /app/build/resources/main/xsd/cp/ex
 COPY --from=builder --chown=appuser:appgroup /app/build/resources/main/xsd/cp/external/StandardCourtList.xsd /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/crime-portal-gateway*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
-COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/AI-Agent.xml /app
 
 USER 2000

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -1,6 +1,0 @@
-{
-  "role": {
-    "name": "crime-portal-gateway",
-    "instance": "crime-portal-gateway"
-  }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("uk.gov.justice.hmpps.gradle-spring-boot") version "2.0.0"
+    id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.1.2"
     kotlin("plugin.spring") version "1.4.10"
     id("org.unbroken-dome.xjc") version "2.0.0"
     id("org.owasp.dependencycheck") version "6.0.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,12 +43,3 @@ xjc {
 sourceSets.named("main") {
     xjcBinding.srcDir("resources/xsd")
 }
-
-tasks.register<Copy>("copyAgentConfig") {
-    from(file("applicationinsights.json"))
-    into(file("$buildDir/libs"))
-}
-
-tasks.assemble {
-    dependsOn("copyAgentConfig")
-}


### PR DESCRIPTION
Undoing upgrade to App Insights Agent version 3.0.0 as there are known issues with this version around dynamically populated customDimensions. Given this codebase doesn't make use of WebFlux (which was the main driving factor for the upgrade to 3.0.0) Agent version 2.6.2 is better supported as of now.