### PR TITLE
✨ PIC-1024 optionally put message on the queue asynchronously. 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/xml/DocumentUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/xml/DocumentUtils.kt
@@ -11,11 +11,13 @@ object DocumentUtils {
 
     private const val OU_CODE_LENGTH = 5
 
+    private const val SOURCE_FILE_NAME = "source_file_name"
+
     private const val SOURCE_FILE_NAME_EXPR = "//source_file_name/text()"
 
     private const val DELIMITER = "_"
 
-    fun getCourtCode(documents: Element): String? {
+    fun getCourtCodeByXPath(documents: Element): String? {
         // XPathFactory not thread safe so make one each time
         val xPath: XPath = XPathFactory.newInstance().newXPath()
         val exp = xPath.compile(SOURCE_FILE_NAME_EXPR)
@@ -29,7 +31,23 @@ object DocumentUtils {
         return null
     }
 
-    private fun getOuCode(item: Node): String? {
+    fun getCourtCode(documents: Element): String? {
+        val sourceFileNameNodes = documents.getElementsByTagName(SOURCE_FILE_NAME)
+        for (j in 0 until sourceFileNameNodes.length) {
+            val sourceFileNameElement = sourceFileNameNodes.item(j) as Element
+            val childTextNodes: NodeList = sourceFileNameElement.childNodes
+            for (k in 0 until childTextNodes.length) {
+                return getOuCode(childTextNodes.item(k))
+            }
+        }
+        return null
+    }
+
+    fun getCourtCode(documents: Element, useXPath: Boolean): String? {
+        return if (useXPath) getCourtCodeByXPath(documents) else getCourtCode(documents)
+    }
+
+    fun getOuCode(item: Node): String? {
         // Source filename has the following format 146_27072020_2578_B01OB00_ADULT_COURT_LIST_DAILY
         val fileNameParts: Array<String> = item.nodeValue?.split(DELIMITER)?.toTypedArray() ?: emptyArray()
         if (fileNameParts.size >= 4) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,5 @@ ws-sec:
   encryption-sym-algorithm: "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
 
 included-court-codes: "B14LO,B14AV,B14ET,B62DC,B20BL,B01GU,B10JQ,B10JJ,B10BD,B16HE,B16BG"
+enqueue-msg-async: true
+use-xpath-for-court-code: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/endpoint/ExternalDocRequestEndpointTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/endpoint/ExternalDocRequestEndpointTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.crimeportalgateway.endpoint
 
+import com.nhaarman.mockitokotlin2.timeout
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -16,6 +19,7 @@ import org.springframework.core.io.ResourceLoader
 import uk.gov.justice.digital.hmpps.crimeportalgateway.service.SqsService
 import uk.gov.justice.digital.hmpps.crimeportalgateway.service.TelemetryEventType
 import uk.gov.justice.digital.hmpps.crimeportalgateway.service.TelemetryService
+import uk.gov.justice.magistrates.external.externaldocumentrequest.Acknowledgement
 import uk.gov.justice.magistrates.external.externaldocumentrequest.ExternalDocumentRequest
 import java.io.File
 import java.io.StringReader
@@ -28,6 +32,8 @@ import javax.xml.validation.SchemaFactory
 @ExtendWith(MockitoExtension::class)
 internal class ExternalDocRequestEndpointTest {
 
+    private lateinit var externalDocument: ExternalDocumentRequest
+
     @Mock
     private lateinit var telemetryService: TelemetryService
 
@@ -38,23 +44,56 @@ internal class ExternalDocRequestEndpointTest {
 
     @BeforeEach
     fun beforeEach() {
-        endpoint = ExternalDocRequestEndpoint(setOf("B10JQ"), telemetryService, sqsService, jaxbContext, schema)
+        endpoint = buildEndpoint(setOf("B10JQ"), false)
+        externalDocument = marshal(xmlFile.readText())
     }
 
     @Test
-    fun `given success should the correct acknowledgement message`() {
-
-        val externalDocument = marshal(xmlFile.readText())
+    fun `given a valid message then should enqueue the message and return the correct acknowledgement`() {
 
         whenever(sqsService.enqueueMessage(contains("ExternalDocumentRequest")))
             .thenReturn("a4e9ab53-f8aa-bf2c-7291-d0293a8b0d02")
 
         val ack = endpoint.processRequest(externalDocument)
 
+        assertAck(ack)
+
         verify(telemetryService).trackEvent(TelemetryEventType.COURT_LIST_MESSAGE_RECEIVED)
         verify(sqsService).enqueueMessage(anyString())
+        verifyNoMoreInteractions(sqsService, telemetryService)
+    }
+
+    @Test
+    fun `given a message for a court which is not in the include list then should not enqueue message`() {
+
+        endpoint = buildEndpoint(setOf("XXXXX"), false)
+
+        val ack = endpoint.processRequest(externalDocument)
+
+        assertAck(ack)
+
+        verifyZeroInteractions(telemetryService, sqsService)
+    }
+
+    @Test
+    fun `given async then success should the correct acknowledgement message`() {
+
+        endpoint = buildEndpoint(setOf("B10JQ"), true)
+
+        whenever(sqsService.enqueueMessage(contains("ExternalDocumentRequest")))
+            .thenReturn("a4e9ab53-f8aa-bf2c-7291-d0293a8b0d02")
+
+        val ack = endpoint.processRequest(externalDocument)
+
+        assertAck(ack)
+        verify(telemetryService, timeout(TIMEOUT_MS)).trackEvent(TelemetryEventType.COURT_LIST_MESSAGE_RECEIVED)
+        verify(sqsService, timeout(TIMEOUT_MS)).enqueueMessage(anyString())
+        verifyNoMoreInteractions(sqsService, telemetryService)
+    }
+
+    private fun assertAck(ack: Acknowledgement) {
         assertThat(ack).isNotNull
-        assertThat(ack.ackType.messageComment).isEqualTo("Message successfully enqueued with id a4e9ab53-f8aa-bf2c-7291-d0293a8b0d02")
+        assertThat(ack.ackType.messageComment).isEqualTo("MessageComment")
         assertThat(ack.ackType.messageStatus).isEqualTo("Success")
         assertThat(ack.ackType.timeStamp).isNotNull
     }
@@ -64,8 +103,21 @@ internal class ExternalDocRequestEndpointTest {
         return marshaller.unmarshal(StringReader(request)) as ExternalDocumentRequest
     }
 
+    private fun buildEndpoint(includedCourts: Set<String>, aSync: Boolean): ExternalDocRequestEndpoint {
+        return ExternalDocRequestEndpoint(
+            includedCourts = includedCourts,
+            enqueueMsgAsync = aSync,
+            xPathForCourtCode = true,
+            telemetryService = telemetryService,
+            sqsService = sqsService,
+            jaxbContext = jaxbContext,
+            validationSchema = schema
+        )
+    }
+
     companion object {
 
+        private const val TIMEOUT_MS: Long = 5000
         private lateinit var xmlFile: File
         private lateinit var jaxbContext: JAXBContext
         private lateinit var schema: Schema

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/integration/endpoint/ExternalDocRequestEndpointIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/integration/endpoint/ExternalDocRequestEndpointIntTest.kt
@@ -59,7 +59,7 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
             .andExpect(validPayload(xsdResource))
             .andExpect(
                 xpath("//ns3:Acknowledgement/ackType/MessageComment", namespaces)
-                    .evaluatesTo("Message successfully enqueued with id $sqsMessageId")
+                    .evaluatesTo("MessageComment")
             )
             .andExpect(
                 xpath("//ns3:Acknowledgement/ackType/MessageStatus", namespaces)
@@ -81,7 +81,7 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
             .andExpect(validPayload(xsdResource))
             .andExpect(
                 xpath("//ns3:Acknowledgement/ackType/MessageComment", namespaces)
-                    .evaluatesTo("Message ignored - the court B10XX in the message is not processed")
+                    .evaluatesTo("MessageComment")
             )
             .andExpect(
                 xpath("//ns3:Acknowledgement/ackType/MessageStatus", namespaces)
@@ -101,7 +101,7 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
             .andExpect(validPayload(xsdResource))
             .andExpect(
                 xpath("//ns3:Acknowledgement/ackType/MessageComment", namespaces)
-                    .evaluatesTo("Message ignored - no court code found in the message")
+                    .evaluatesTo("MessageComment")
             )
             .andExpect(
                 xpath("//ns3:Acknowledgement/ackType/MessageStatus", namespaces)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/xml/DocumentUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/xml/DocumentUtilsTest.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.crimeportalgateway.xml
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.w3c.dom.Document
 import org.xml.sax.InputSource
 import java.io.File
@@ -20,45 +21,49 @@ internal class DocumentUtilsTest {
     private val sourceFileName = "5_26102020_2992_B10JQ00_ADULT_COURT_LIST_DAILY"
     private val sourceFileNameElement = "<source_file_name>$sourceFileName</source_file_name>"
 
-    @Test
-    fun `get court code from correctly formed ExternalDocumentRequest`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `get court code from correctly formed ExternalDocumentRequest`(useXPath: Boolean) {
 
         val externalDocument = toXml(StringReader(xmlFile.readText()))
 
-        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement)
+        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement, useXPath)
 
         assertThat(courtCode).isEqualTo("B10JQ")
     }
 
-    @Test
-    fun `get empty set when there is no source_file_name`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `get empty set when there is no source_file_name`(useXPath: Boolean) {
 
         val str: String = xmlFile.readText().replace(sourceFileNameElement, "")
         val externalDocument = toXml(StringReader(str))
 
-        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement)
+        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement, useXPath)
 
         assertThat(courtCode).isNull()
     }
 
-    @Test
-    fun `get empty set when there is no source_file_name value`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `get empty set when there is no source_file_name value`(useXPath: Boolean) {
 
         val str: String = xmlFile.readText().replace(sourceFileNameElement, "<source_file_name />")
         val externalDocument = toXml(StringReader(str))
 
-        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement)
+        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement, useXPath)
 
         assertThat(courtCode).isNull()
     }
 
-    @Test
-    fun `get empty set when source_file_name is invalid`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `get empty set when source_file_name is invalid`(useXPath: Boolean) {
 
         val str: String = xmlFile.readText().replace(sourceFileNameElement, "<source_file_name>5_26102020_2992_</source_file_name>")
         val externalDocument = toXml(StringReader(str))
 
-        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement)
+        val courtCode = DocumentUtils.getCourtCode(externalDocument.documentElement, useXPath)
 
         assertThat(courtCode).isNull()
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,3 +23,6 @@ aws:
 soap:
   xsd-file-path: src/main/resources/xsd/cp/external/ExternalDocumentRequest.xsd
   validate-payload: true
+
+enqueue-msg-async: false
+use-xpath-for-court-code: true


### PR DESCRIPTION
Under test with 1000 / 3000 concurrent requests (to a single pod), large client timeouts were observed.
Upon message receipt, the following things have to happen

1. get the court code (xPath)
2. marshal the object to a string
3. send telemetry
4. put message on queue
5. send the response

In the dev namespace, we could observe that the whole process would take some time, with most of the time being in the marshalling. 
So the endpoint now does 1 - 4 asynchronously. This is via an option