### PR TITLE
🔐 cryptacular security advisory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation("org.springframework.ws:spring-ws-security") {
         exclude(group = "org.bouncycastle", module = "bcprov-jdk15on")
             .because("OWASP found security Issues")
+        exclude(group = "org.cryptacular", module = "cryptacular")
+            .because("OWASP found security Issues")
     }
     implementation("org.springframework.boot:spring-boot-devtools")
     implementation("org.springframework.boot:spring-boot-starter-web-services")


### PR DESCRIPTION
Have run CPG in secure mode, having removed this dependency and all is OK.

One or more dependencies were identified with known vulnerabilities in crime-portal-gateway:

cryptacular-1.1.1.jar (pkg:maven/org.cryptacular/cryptacular@1.1.1, cpe:2.3:a:vt:cryptacular:1.1.1:*:*:*:*:*:*:*) : CVE-2020-7226