### PR TITLE
🛠 PIC-2679: Fix CI and allow deployment of non-main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ workflows:
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:
+          context: [hmpps-common-vars]
           name: build_docker
           filters:
             branches:
@@ -70,6 +71,7 @@ workflows:
           env: "dev"
           helm_additional_args: --values ./crime-portal-gateway/values-live.yaml
           context:
+            - hmpps-common-vars
             - court-probation-live-dev
           filters:
             branches:
@@ -90,6 +92,7 @@ workflows:
           env: "preprod"
           helm_additional_args: --values ./crime-portal-gateway/values-live.yaml
           context:
+            - hmpps-common-vars
             - court-probation-live-preprod
           requires:
             - request-preprod-approval
@@ -103,6 +106,7 @@ workflows:
           env: "prod"
           helm_additional_args: --values ./crime-portal-gateway/values-live.yaml
           context:
+            - hmpps-common-vars
             - court-probation-live-prod
           slack_notification: true
           slack_channel_name: probation_in_court_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ workflows:
             branches:
               only:
                 - main
+                - /.*deployable_branch.*/
           post-steps:
             - jira/notify:
               job_type: build
@@ -74,6 +75,7 @@ workflows:
             branches:
               only:
                 - main
+                - /.*deployable_branch.*/
           requires:
             - validate
             - build_docker


### PR DESCRIPTION
Updated filters of build and deploy steps of CI config to allow deployment of all branches containing the string 'deployable_branch'. This is to allow pipeline changes to be tested on branches without having to merge into main.