### PR TITLE
Add debug logging for soap requests

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -13,10 +13,6 @@
     </layout>
   </appender>
 
-  <logger name="org.springframework.ws" additivity="false" level="INFO">
-    <appender-ref ref="consoleAppender"/>
-  </logger>
-
   <logger name="uk.gov.justice.digital.hmpps.crimeportalgateway.CrimePortalGatewayKt" additivity="false" level="DEBUG">
     <appender-ref ref="consoleAppender"/>
   </logger>
@@ -33,16 +29,16 @@
     <appender-ref ref="consoleAppender"/>
   </logger>
 
-  <logger name="org.springframework" additivity="false" level="INFO">
+  <logger name="org.springframework" additivity="false" level="WARN">
     <appender-ref ref="consoleAppender"/>
   </logger>
 
-  <logger name="org.apache.catalina" additivity="false" level="INFO">
+  <logger name="org.apache.catalina" additivity="false" level="WARN">
     <appender-ref ref="consoleAppender"/>
   </logger>
 
-  <logger name="org.springframework.ws">
-    <level value="TRACE"/>
+  <logger name="org.springframework.ws" additivity="false" level="TRACE">
+    <appender-ref ref="consoleAppender"/>
   </logger>
 
   <logger name="org.springframework.boot" additivity="false" level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -41,11 +41,15 @@
     <appender-ref ref="consoleAppender"/>
   </logger>
 
+  <logger name="org.springframework.ws">
+    <level value="TRACE"/>
+  </logger>
+
   <logger name="org.springframework.boot" additivity="false" level="INFO">
     <appender-ref ref="consoleAppender"/>
   </logger>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="consoleAppender"/>
   </root>
 


### PR DESCRIPTION
Add debug logging for soap requests


We are trying to manually regression test preprod by sending test xml data. However, we're getting this error:
`SAAJ0511: Unable to create envelope from given source`


By adding extra logging, we may be able to debug the issue here