### PR TITLE
PIC-4117 Update location of Keystore in PreProd

### DIFF
--- a/helm_deploy/crime-portal-gateway/templates/deployment.yaml
+++ b/helm_deploy/crime-portal-gateway/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: "crime-portal-gateway-keystore-cert"
+            secretName: {{ .Values.secretName }}
             items:
               - key: crime-portal-gateway-jks.key
                 path: crime-portal-gateway-jks.key

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,8 @@
 minReplicaCount: 1
 maxReplicaCount: 2
 
+secretName: "crime-portal-gateway-keystore-cert"
+
 image:
   repository: quay.io/hmpps/crime-portal-gateway
   tag: latest

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,8 @@
 minReplicaCount: 2
 maxReplicaCount: 4
 
+secretName: "crime-portal-gateway-keystore-cert-testing"
+
 image:
   repository: quay.io/hmpps/crime-portal-gateway
   tag: latest

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,6 +4,8 @@
 minReplicaCount: 2
 maxReplicaCount: 4
 
+secretName: "crime-portal-gateway-keystore-cert"
+
 image:
   repository: quay.io/hmpps/crime-portal-gateway
   tag: latest


### PR DESCRIPTION
Update the location of the keystore in PreProd to the new k8s secret that contains our local testing Keystore.

Keep dev and prod using the existing keystore values in the existing k8s secret (associated with Libra/HMCTS/CGI)

Update the deployment file to point to a Helm values file to dynamically get the secretName