### PR TITLE
Exclude duplicated dependency on jaxb-core-4.0.5 to fix :bootJar gradle task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,9 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-sts:$awsSdkVersion")
 
     implementation("wsdl4j:wsdl4j:1.6.3")
-    implementation("com.sun.xml.bind:jaxb-impl:4.0.5")
+    implementation("com.sun.xml.bind:jaxb-impl:4.0.5") {
+        exclude(group = "com.sun.xml.bind", module = "jaxb-core")
+    }
     implementation("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
 
     xjcTool("com.sun.xml.bind:jaxb-xjc:3.0.2")


### PR DESCRIPTION
Exclude jaxb-core-4.0.5 from com.sun.xml.bind:jaxb-impl as spring-ws pulls in that dependency already.

This resolves the below error:

```
Execution failed for task ':bootJar'.
Entry BOOT-INF/lib/jaxb-core-4.0.5.jar is a duplicate but no duplicate handling strategy has been set
```