### PR TITLE
PIC-4153 disable csrf to make end points accessible

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/InfoSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/InfoSecurityConfig.kt
@@ -3,13 +3,9 @@ package uk.gov.justice.digital.hmpps.crimeportalgateway.application
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.test.context.ActiveProfiles
 
 @Configuration
-@EnableWebSecurity
-@ActiveProfiles("test")
 class InfoSecurityConfig {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {


### PR DESCRIPTION
Since we brought in https://github.com/ministryofjustice/hmpps-spring-boot-sqs it appears that some endpoint security configuration has come along with it.

```
2024-09-16 11:37:51.849 DEBUG 1 --- [nio-8081-exec-8] o.s.security.web.FilterChainProxy        : Securing POST /crime-portal-gateway/ws/ | trace_id=c5950fe9124ebea4ebc50fe3c7209563, trace_flags=01, span_id=2d67bbbe871b4868 
2024-09-16 11:37:51.859 DEBUG 1 --- [nio-8081-exec-8] o.s.security.web.csrf.CsrfFilter         : Invalid CSRF token found for https://crime-portal-gateway-dev.apps.live-1.cloud-platform.service.justice.gov.uk/crime-portal-gateway/ws/ | trace_id=c5950fe9124ebea4ebc50fe3c7209563, trace_flags=01, span_id=2d67bbbe871b4868 
2024-09-16 11:37:51.860 DEBUG 1 --- [nio-8081-exec-8] o.s.s.w.access.AccessDeniedHandlerImpl   : Responding with 403 status code | trace_id=c5950fe9124ebea4ebc50fe3c7209563, trace_flags=01, span_id=2d67bbbe871b4868 
```

[This from the test-app](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/blob/5c1bf9695d5e8ba86e1460afbb672cd4aea7e787/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/config/ResourceServerConfiguration.kt#L20)
Suggests it is OK to disable csrf