### PR TITLE
PIC-4149 environment variables use - instead of _ for consistency

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
@@ -18,8 +18,8 @@ class WebServiceSecurityConfig(
     @Value("\${ws-sec.response-encrypt-actions}") private val responseActions: String,
     @Value("\${ws-sec.response-signature-parts}") private val responseSignatureParts: String,
     @Value("\${ws-sec.response-encryption-parts}") private val responseEncryptionParts: String,
-    @Value("\${trusted_cert_alias_name}") private val trustedCertAliasName: String,
-    @Value("\${private_key_alias_name}") private val privateKeyAliasName: String,
+    @Value("\${trusted-cert-alias-name}") private val trustedCertAliasName: String,
+    @Value("\${private-key-alias-name}") private val privateKeyAliasName: String,
     @Value("\${ws-sec.keystore-file-path}") private val keystoreFilePath: String,
     @Value("\${ws-sec.encryption-sym-algorithm}") private val encryptionAlgorithm: String,
 ) {


### PR DESCRIPTION
The pod startup in preprod is failing with this message
`Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'trusted_cert_alias_name' in value "${trusted_cert_alias_name}"`

It works in dev because the `secure` Spring profile is not enabled there

see https://github.com/ministryofjustice/crime-portal-gateway/blob/78c5d89bbe151a9ac621d69781c7e730ec5efde5/helm_deploy/crime-portal-gateway/values.yaml#L43

