### PR TITLE
PIC-4149 Fix xml-security issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.crimeportalgateway.application
 
+import org.apache.xml.security.Init
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -47,6 +48,7 @@ class WebServiceSecurityConfig(
 
         // validate incoming request
         securityInterceptor.setValidationActions(requestActions)
+        Init.init();
         securityInterceptor.setValidationSignatureCrypto(getValidationCryptoFactoryBean().getObject())
         securityInterceptor.setValidationDecryptionCrypto(getValidationCryptoFactoryBean().getObject())
         securityInterceptor.setValidationCallbackHandler(keyStoreCallbackHandler())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
@@ -34,6 +34,7 @@ class WebServiceSecurityConfig(
 
     @Bean
     fun getValidationCryptoFactoryBean(): CryptoFactoryBean {
+        Init.init()
         val cryptoFactoryBean = CryptoFactoryBean()
         cryptoFactoryBean.setKeyStoreLocation(FileSystemResource(keystoreFilePath))
         cryptoFactoryBean.setKeyStorePassword(keystorePassword)
@@ -48,7 +49,6 @@ class WebServiceSecurityConfig(
 
         // validate incoming request
         securityInterceptor.setValidationActions(requestActions)
-        Init.init()
         securityInterceptor.setValidationSignatureCrypto(getValidationCryptoFactoryBean().getObject())
         securityInterceptor.setValidationDecryptionCrypto(getValidationCryptoFactoryBean().getObject())
         securityInterceptor.setValidationCallbackHandler(keyStoreCallbackHandler())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/application/WebServiceSecurityConfig.kt
@@ -48,7 +48,7 @@ class WebServiceSecurityConfig(
 
         // validate incoming request
         securityInterceptor.setValidationActions(requestActions)
-        Init.init();
+        Init.init()
         securityInterceptor.setValidationSignatureCrypto(getValidationCryptoFactoryBean().getObject())
         securityInterceptor.setValidationDecryptionCrypto(getValidationCryptoFactoryBean().getObject())
         securityInterceptor.setValidationCallbackHandler(keyStoreCallbackHandler())


### PR DESCRIPTION
Initialize xml-security before calling `getValidationCryptoFactoryBean`

This fixes:

```
Error creating bean with name 'getValidationCryptoFactoryBean'
...
Caused by: org.apache.wss4j.common.ext.WSSecurityException:
You must initialize the xml-security library correctly before you use it.
 Call the static method "org.apache.xml.security.Init.init();"
  to do that before you use any functionality from that library.
```