### PR TITLE
PIC-4149 Update the config key for ingress

### DIFF
--- a/helm_deploy/crime-portal-gateway/values.yaml
+++ b/helm_deploy/crime-portal-gateway/values.yaml
@@ -15,7 +15,7 @@ generic-service:
       - app-hostname.local    # override per environment
     path: /mirrorgateway/service/cpmgwextdocapi(/|$)(.*)
     annotations:
-      rewrite_target: /crime-portal-gateway/ws/$2
+      nginx.ingress.kubernetes.io/rewrite_target: /crime-portal-gateway/ws/$2
 
   autoscaling:
     enabled: true


### PR DESCRIPTION
Update `rewrite_target` key to `nginx.ingress.kubernetes.io/`

This is because the deployments failed after using the hmpps helm charts. 

**More info here:**

https://kubernetes.github.io/ingress-nginx/examples/rewrite/#deployment