### PR TITLE
PIC-4134 crime portal gateway uses court-facing-api service account

### DIFF
--- a/helm_deploy/crime-portal-gateway/values.yaml
+++ b/helm_deploy/crime-portal-gateway/values.yaml
@@ -1,7 +1,7 @@
 generic-service:
   nameOverride: crime-portal-gateway
 
-  serviceAccountName: "court-case-service"
+  serviceAccountName: "court-facing-api"
 
   image:
     repository: quay.io/hmpps/crime-portal-gateway


### PR DESCRIPTION
This has S3 and SNS permissions which is all that crime portal gateway needs. This change has already been made to court hearing event receiver