### PR TITLE
PIC-4364 Publish messages to SNS FIFO Topic

### DIFF
--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -22,6 +22,17 @@
           }
         ],
         "percentage": 100
+      },
+      {
+        "telemetryType": "exception",
+        "attributes": [
+          {
+            "key": "exception.type",
+            "value": "java.util.concurrent.CompletionException",
+            "matchType": "strict"
+          }
+        ],
+        "percentage": 10
       }
     ]
   },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ dependencyCheck {
 
 dependencies {
 
-    implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:4.4.2")
+    implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.2.1")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     implementation("org.springframework.ws:spring-ws-security:4.0.1") {

--- a/helm_deploy/crime-portal-gateway/values.yaml
+++ b/helm_deploy/crime-portal-gateway/values.yaml
@@ -34,7 +34,7 @@ generic-service:
   namespace_secrets:
     crime-portal-gateway:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-    court-case-events-topic:
+    court-cases-topic:
       HMPPS_SQS_TOPICS_COURTCASEEVENTSTOPIC_ARN: topic_arn
     crime-portal-gateway-s3-credentials:
       aws_s3_bucket_name: bucket_name

--- a/helm_deploy/crime-portal-gateway/values.yaml
+++ b/helm_deploy/crime-portal-gateway/values.yaml
@@ -35,7 +35,7 @@ generic-service:
     crime-portal-gateway:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
     court-cases-topic:
-      HMPPS_SQS_TOPICS_COURTCASEEVENTSTOPIC_ARN: topic_arn
+      HMPPS_SQS_TOPICS_COURTCASESTOPIC_ARN: topic_arn
     crime-portal-gateway-s3-credentials:
       aws_s3_bucket_name: bucket_name
     crime-portal-gateway-secrets:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/messaging/MessageNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/messaging/MessageNotifier.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.hmpps.sqs.MissingTopicException
 import uk.gov.justice.hmpps.sqs.publish
 
 private const val MESSAGE_TYPE = "LIBRA_COURT_CASE"
+private const val MESSAGE_GROUP_ID = "CRIME_PORTAL_GATEWAY"
 
 @Component
 class MessageNotifier(
@@ -31,7 +32,7 @@ class MessageNotifier(
                 .dataType("String")
                 .stringValue(MESSAGE_TYPE).build()
 
-        val publishResult = topic.publish("libra.case.received", message, mapOf("messageType" to messageValue))
+        val publishResult = topic.publish("libra.case.received", message, attributes = mapOf("messageType" to messageValue), messageGroupId = MESSAGE_GROUP_ID)
         log.info("Published message with subject {} with message Id {}", subject, publishResult.messageId())
         telemetryService.trackCourtCaseSplitEvent(case, publishResult.messageId())
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/messaging/MessageNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/messaging/MessageNotifier.kt
@@ -20,7 +20,7 @@ class MessageNotifier(
     private val hmppsQueueService: HmppsQueueService,
 ) {
     private val topic =
-        hmppsQueueService.findByTopicId("courtcaseeventstopic")
+        hmppsQueueService.findByTopicId("courtcasestopic")
             ?: throw MissingTopicException("Could not find topic ")
 
     fun send(case: Case) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,14 +16,14 @@ hmpps.sqs:
   enabled: true
   provider: localstack
   queues:
-    courtcaseeventsqueue:
-      queueName: court_case_events_queue
-      subscribeTopicId: courtcaseeventstopic
-      dlqName: cpr_court_case_events_queue_dlq
+    courtcasesqueue:
+      queueName: court_cases_queue.fifo
+      subscribeTopicId: courtcasestopic
+      dlqName: cpr_court_cases_queue_dlq.fifo
       dlqMaxReceiveCount: 1
   topics:
-    courtcaseeventstopic:
-      arn: "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+    courtcasestopic:
+      arn: "arn:aws:sns:eu-west-2:000000000000:court-cases-topic.fifo"
 
 # Localstack settings for S3
 aws:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/integration/endpoint/ExternalDocRequestEndpointIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/integration/endpoint/ExternalDocRequestEndpointIntTest.kt
@@ -235,7 +235,9 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
             val sqsMessage: SQSMessage = objectMapper.readValue(message.messages()[0].body(), SQSMessage::class.java)
 
             cases.add(objectMapper.readValue(sqsMessage.message, CaseDetails::class.java))
-            courtCaseEventsQueue?.sqsClient?.deleteMessage(DeleteMessageRequest.builder().queueUrl(courtCaseEventsQueue?.queueUrl!!).receiptHandle(message.messages()[0].receiptHandle()).build())
+            courtCaseEventsQueue?.sqsClient?.deleteMessage(
+                DeleteMessageRequest.builder().queueUrl(courtCaseEventsQueue?.queueUrl!!).receiptHandle(message.messages()[0].receiptHandle()).build(),
+            )
         }
         assertThat(cases).containsAll(expectedCases)
         return cases

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/integration/endpoint/ExternalDocRequestEndpointIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/crimeportalgateway/integration/endpoint/ExternalDocRequestEndpointIntTest.kt
@@ -153,7 +153,7 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
         val firstCase = CaseDetails(caseNo = 166662981, defendantName = "MR Abraham LINCOLN", pnc = "20030011985X", cro = "CR0006100061")
         val secondCase = CaseDetails(caseNo = 1777732980, defendantName = "Mr Theremin MELLOTRON", pnc = "20120052494Q", cro = "CR0006200062")
 
-        assertThat(checkMessage(listOf(firstCase, secondCase))).hasSize(2)
+        checkMessage(listOf(firstCase, secondCase))
         checkQueueIsEmpty()
 
         checkS3Upload("2020-10-26-B10")
@@ -227,7 +227,7 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
 
     private fun readFile(fileName: String): String = File(fileName).readText(Charsets.UTF_8)
 
-    private fun checkMessage(expectedCases: List<CaseDetails>): MutableList<CaseDetails> {
+    private fun checkMessage(expectedCases: List<CaseDetails>) {
         val cases = mutableListOf<CaseDetails>()
         await().until { countMessagesOnQueue() == 2 }
         while (countMessagesOnQueue() > 0) {
@@ -240,7 +240,7 @@ class ExternalDocRequestEndpointIntTest : IntegrationTestBase() {
             )
         }
         assertThat(cases).containsAll(expectedCases)
-        return cases
+        assertThat(cases).containsOnly(expectedCases[0], expectedCases[1])
     }
 
     companion object {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,13 +14,13 @@ hmpps.sqs:
   provider: localstack
   queues:
     courtcaseeventsqueue:
-      queueName: court_case_events_queue
+      queueName: court_cases_queue.fifo
       subscribeTopicId: courtcaseeventstopic
-      dlqName: cpr_court_case_events_queue_dlq
+      dlqName: cpr_court_cases_queue_dlq.fifo
       dlqMaxReceiveCount: 1
   topics:
     courtcaseeventstopic:
-      arn: "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+      arn: "arn:aws:sns:eu-west-2:000000000000:court-cases-topic.fifo"
 
 # Localstack settings for S3
 aws:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,13 +13,13 @@ hmpps.sqs:
   enabled: true
   provider: localstack
   queues:
-    courtcaseeventsqueue:
+    courtcasesqueue:
       queueName: court_cases_queue.fifo
-      subscribeTopicId: courtcaseeventstopic
+      subscribeTopicId: courtcasestopic
       dlqName: cpr_court_cases_queue_dlq.fifo
       dlqMaxReceiveCount: 1
   topics:
-    courtcaseeventstopic:
+    courtcasestopic:
       arn: "arn:aws:sns:eu-west-2:000000000000:court-cases-topic.fifo"
 
 # Localstack settings for S3


### PR DESCRIPTION
1. Update to send message to SNS FIFO topic 👀 

2. Upgrade `uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.2.1` to major version 5. 

`v5.2.1` has the update to the HMPPSTopic.publish method to allow for the MessageGroupID to be passed in. MessageGroupID is a required key/value when sending message to a FIFO topic.

Update the local-stack sns and sqs resources to FIFO.